### PR TITLE
Misc ID Site Modifcations

### DIFF
--- a/assets/templates/stormpath-settings.php
+++ b/assets/templates/stormpath-settings.php
@@ -250,7 +250,7 @@
 								<span id="helpBlock" class="help-block">A list of URLs that the user can be sent to after they login or register at the ID Site. One URL per line.</span>
 								<?php $callback_path = apply_filters('stormpath_callback_path', 'stormpath/callback')
 								; ?>
-								<span id="helpBlock" class="help-block">Please make sure <?php echo( get_site_url() . "/{$callback_path}" ); ?> is added here, otherwise ID Site will not work.</span>
+								<span id="helpBlock" class="help-block">Please make sure <?php echo( get_home_url() . "/{$callback_path}" ); ?> is added here, otherwise ID Site will not work.</span>
 							</div>
 						</div>
 

--- a/lib/Stormpath.php
+++ b/lib/Stormpath.php
@@ -97,7 +97,7 @@ class Stormpath {
 
 		add_filter( 'allowed_redirect_hosts' , [ $this, 'stormpath_allowed_redirect_hosts' ] , 10 );
 		add_filter( 'plugin_action_links_' . plugin_basename( STORMPATH_BASEFILE ), [ PluginManager::class, 'add_action_links' ] );
-		add_filter( 'template_include', [ IdSiteManager::class, 'add_id_site_callback' ] );
+		add_filter( 'init', [ IdSiteManager::class, 'add_id_site_callback' ] );
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_resources' ) );
 		add_action( 'admin_menu', array( $this, 'admin_menus' ) );

--- a/lib/hooks/IdSiteManager.php
+++ b/lib/hooks/IdSiteManager.php
@@ -84,9 +84,6 @@ class IdSiteManager {
 			} catch ( \Exception $e ) {
 				wp_die( esc_html( $e->getMessage() ) );
 			}
-
-			wp_safe_redirect( admin_url() );
-			exit;
 		}
 
 		return $template;
@@ -108,7 +105,13 @@ class IdSiteManager {
 
 		do_action( 'stormpath_callback_logout', $response );
 
-		wp_safe_redirect( home_url() );
+		$redirect_to = '/wp-login.php?loggedout=true';
+
+		$user = get_user_by( 'email', $response->account->email );
+
+		$redirect_to = apply_filters( 'logout_redirect', $redirect_to, '', $user );
+
+		wp_safe_redirect( $redirect_to );
 		exit;
 	}
 
@@ -138,8 +141,9 @@ class IdSiteManager {
 
 		do_action( 'stormpath_callback_authenticate', $response );
 
-		return;
-
+		$redirect_to = apply_filters( 'login_redirect', admin_url(), '' , wp_get_current_user() );
+		wp_safe_redirect( $redirect_to );
+		exit;
 	}
 
 	/**

--- a/lib/hooks/IdSiteManager.php
+++ b/lib/hooks/IdSiteManager.php
@@ -106,6 +106,8 @@ class IdSiteManager {
 			)) );
 		}
 
+		do_action( 'stormpath_callback_logout', $response );
+
 		wp_safe_redirect( home_url() );
 		exit;
 	}
@@ -133,6 +135,9 @@ class IdSiteManager {
 
 		wp_set_current_user( $user->ID, $user->user_login );
 		wp_set_auth_cookie( $user->ID );
+
+		do_action( 'stormpath_callback_authenticate', $response );
+
 		return;
 
 	}

--- a/lib/hooks/IdSiteManager.php
+++ b/lib/hooks/IdSiteManager.php
@@ -112,7 +112,7 @@ class IdSiteManager {
 
 		do_action( 'stormpath_callback_logout', $response );
 
-		$redirect_to = '/wp-login.php?loggedout=true';
+		$redirect_to = site_url( '/wp-login.php?loggedout=true' );
 
 		$user = get_user_by( 'email', $response->account->email );
 

--- a/lib/hooks/LoginManager.php
+++ b/lib/hooks/LoginManager.php
@@ -75,7 +75,7 @@ class LoginManager {
 		$application = Application::get_instance();
 		$callback_path = apply_filters( 'stormpath_callback_path', 'stormpath/callback' );
 		wp_safe_redirect( $application->get_application()->createIdSiteUrl( [
-			'callbackUri' => get_site_url() . "/{$callback_path}",
+			'callbackUri' => get_home_url() . "/{$callback_path}",
 		] ) );
 		exit;
 	}
@@ -91,7 +91,7 @@ class LoginManager {
 		if ( $this->useIdSite ) {
 			$application = Application::get_instance();
 			$callback_path = apply_filters( 'stormpath_callback_path', 'stormpath/callback' );
-			$properties = [ 'callbackUri' => get_site_url() . "/{$callback_path}", 'logout' => true ];
+			$properties = [ 'callbackUri' => get_home_url() . "/{$callback_path}", 'logout' => true ];
 
 			if ( null !== $state ) {
 				$properties['state'] = $state;


### PR DESCRIPTION
Hi @bretterer thought id' just submit a PR to prototype/demonstrate some of the changes I mentioned [here](https://github.com/stormpath/stormpath-wordpress/issues/6#issuecomment-279105302).

* 9f9df47 swaps to using the `home_url` instead of the `site_url`
* 036365a adds in some action hooks on the stormpath callback after the response has been handled and before any redirects have taken place (so that the response etc. is still accessible for doing things like grabbing tokens)
* e2110c6 hooks onto `init` rather than filering `template_include` (mainly because it was never modifying what template was displayed anyway)

Feel free to cherry pick, feedback, discard etc.