### PR TITLE
Allow Stormpath ID, Secret and Application to be defined within WP configuration

### DIFF
--- a/assets/templates/stormpath-settings.php
+++ b/assets/templates/stormpath-settings.php
@@ -21,22 +21,23 @@
  *
  * @package Stormpath\WordPress;
  */
+
+$application_href = defined( 'STORMPATH_APPLICATION' ) ? STORMPATH_APPLICATION : get_option( 'stormpath_application' );
+
+if ( \Stormpath\WordPress\ApiKeys::get_instance()->api_keys_valid() && '' != $application_href ) {
+	update_option( 'stormpath_installed', true, false );
+} else {
+	update_option( 'stormpath_installed', false, false );
+}
+
+$nonce = wp_create_nonce( "stormpath-settings-nonce" );
+
 ?>
-<?php if ( \Stormpath\WordPress\ApiKeys::get_instance()->api_keys_valid() && '' != get_option( 'stormpath_application' ) ) : ?>
-	<?php update_option( 'stormpath_installed', true, false ); ?>
-<?php else: ?>
-	<?php update_option( 'stormpath_installed', false, false ); ?>
-<?php endif; ?>
-
-
-<?php $nonce = wp_create_nonce( "stormpath-settings-nonce" ); ?>
 <div class="stormpath-settings-wrap" id="stormpath-settings" data-nonce="<?php esc_html_e($nonce); ?>">
 
 	<section class="stormpath-page-header">
 		<img class="stormpath-header-logo" src="<?php esc_html_e( STORMPATH_PLUGIN_ROOT_URL . 'assets/images/logo.png' ); ?>" />
 	</section>
-
-
 
 	<div class="row">
 
@@ -47,16 +48,28 @@
 					<h3>Settings</h3>
 				</div>
 				<div class="stormpath-container-body">
-					<form method="POST" action="options.php" class="form-horizontal">
-						<?php settings_fields( 'stormpath-settings' ); ?>
-						<?php do_settings_sections( 'stormpath-settings' ); ?>
 
-						<?php include STORMPATH_BASEPATH .'/assets/templates/_partials/apiKey_form_fields.php'; ?>
+					<?php if ( defined( 'STORMPATH_CLIENT_APIKEY_ID' ) && defined( 'STORMPATH_CLIENT_APIKEY_SECRET' ) && defined( 'STORMPATH_APPLICATION' ) ) { ?>
 
-						<?php include STORMPATH_BASEPATH .'/assets/templates/_partials/application_selection.php'; ?>
+						<p>Stormpath settings have been defined in your WordPress configuration file/s.</p>
 
-						<?php submit_button( 'Update Settings', 'button-stormpath', 'submit', true, [ 'class' => 'stormpath-submit' ] ); ?>
-					</form>
+					<?php } else { ?>
+
+						<form method="POST" action="options.php" class="form-horizontal">
+
+							<?php settings_fields( 'stormpath-settings' ); ?>
+
+							<?php do_settings_sections( 'stormpath-settings' ); ?>
+
+							<?php include STORMPATH_BASEPATH .'/assets/templates/_partials/apiKey_form_fields.php'; ?>
+
+							<?php include STORMPATH_BASEPATH .'/assets/templates/_partials/application_selection.php'; ?>
+
+							<?php submit_button( 'Update Settings', 'button-stormpath', 'submit', true, [ 'class' => 'stormpath-submit' ] ); ?>
+
+						</form>
+
+					<?php } ?>
 
 				</div>
 			</div>

--- a/lib/ApiKeys.php
+++ b/lib/ApiKeys.php
@@ -68,8 +68,8 @@ class ApiKeys {
 	 * ApiKeys constructor.
 	 */
 	protected function __construct() {
-		$this->apiKeyId = get_option( 'stormpath_client_apikey_id' );
-		$this->apiKeySecret = get_option( 'stormpath_client_apikey_secret' );
+		$this->apiKeyId = ( defined( 'STORMPATH_CLIENT_APIKEY_ID' ) ) ? STORMPATH_CLIENT_APIKEY_ID : get_option( 'stormpath_client_apikey_id' );
+		$this->apiKeySecret = ( defined( 'STORMPATH_CLIENT_APIKEY_SECRET' ) ) ? STORMPATH_CLIENT_APIKEY_SECRET : get_option( 'stormpath_client_apikey_secret' );
 	}
 
 	/**

--- a/lib/Application.php
+++ b/lib/Application.php
@@ -103,8 +103,9 @@ class Application {
 	public function get_application() {
 		if ( null === $this->application ) {
 			try {
+				$application_href = defined( 'STORMPATH_APPLICATION' ) ? STORMPATH_APPLICATION : get_option( 'stormpath_application' );
 				$this->application = $this->client->get_client()->getDataStore()->getResource(
-					get_option( 'stormpath_application' ),
+					$application_href,
 					\Stormpath\Stormpath::APPLICATION,
 					[]
 				);

--- a/lib/hooks/IdSiteManager.php
+++ b/lib/hooks/IdSiteManager.php
@@ -63,7 +63,7 @@ class IdSiteManager {
 
 		$callback_path = apply_filters( 'stormpath_callback_path', 'stormpath/callback' );
 
-		$request_uri = esc_url_raw( $_SERVER['REQUEST_URI'] );
+		$request_uri = $request_uri_no_starting_slash = esc_url_raw( $_SERVER['REQUEST_URI'] );
 
 		// Remove any starting slashes
 		if ( substr( $request_uri, 0, 1 ) == '/' ) {


### PR DESCRIPTION
Prototype/proof-of-concept for allowing the Stormpath ID, Secret and Application to be defined within the WP Configuration (e.g. `wp-config.php` or if dealing with different environments `local-config.php` etc.)

If not defined, it will simply use those stored in WP options.

Example defining then in `wp-config.php`

```
// Stormpath Config
define('STORMPATH_CLIENT_APIKEY_ID', 'XXXXX');
define('STORMPATH_CLIENT_APIKEY_SECRET', 'XXXXXX');
define('STORMPATH_APPLICATION', 'https://api.stormpath.com/v1/applications/XXXX' );
```

If defined, I've opted to hide the settings fields in the dashboard as well to avoid confusion e.g. https://cl.ly/0D3l0s3i0t24